### PR TITLE
Branding update

### DIFF
--- a/blog/2016/01/index.html
+++ b/blog/2016/01/index.html
@@ -669,7 +669,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/02/index.html
+++ b/blog/2016/02/index.html
@@ -737,7 +737,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/03/index.html
+++ b/blog/2016/03/index.html
@@ -693,7 +693,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/04/index.html
+++ b/blog/2016/04/index.html
@@ -695,7 +695,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/05/index.html
+++ b/blog/2016/05/index.html
@@ -462,7 +462,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/index.html
+++ b/blog/2016/index.html
@@ -978,7 +978,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/page/2/index.html
+++ b/blog/2016/page/2/index.html
@@ -919,7 +919,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/2016/page/3/index.html
+++ b/blog/2016/page/3/index.html
@@ -684,7 +684,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/annals-update-protocol-sharing-requirements-for-trialists-after-compare-finds-shortcomings/index.html
+++ b/blog/annals-update-protocol-sharing-requirements-for-trialists-after-compare-finds-shortcomings/index.html
@@ -1030,7 +1030,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/another-ethical-breach-at-annals-misleading-transparency-statements-and-secret-protocols/index.html
+++ b/blog/another-ethical-breach-at-annals-misleading-transparency-statements-and-secret-protocols/index.html
@@ -1061,7 +1061,7 @@ Today we describe a new"
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html
+++ b/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html
@@ -1121,7 +1121,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html?replytocom=175.html
+++ b/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html?replytocom=175.html
@@ -1126,7 +1126,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html?replytocom=176.html
+++ b/blog/are-your-results-unusual-or-how-often-are-outcomes-switched/index.html?replytocom=176.html
@@ -1125,7 +1125,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/aarondale/index.html
+++ b/blog/author/aarondale/index.html
@@ -776,7 +776,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/bengoldacre/index.html
+++ b/blog/author/bengoldacre/index.html
@@ -1017,7 +1017,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/bengoldacre/page/2/index.html
+++ b/blog/author/bengoldacre/page/2/index.html
@@ -589,7 +589,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/carlheneghan/index.html
+++ b/blog/author/carlheneghan/index.html
@@ -638,7 +638,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/henrydrysdale/index.html
+++ b/blog/author/henrydrysdale/index.html
@@ -1021,7 +1021,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/henrydrysdale/page/2/index.html
+++ b/blog/author/henrydrysdale/page/2/index.html
@@ -563,7 +563,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/author/kamalmahtani/index.html
+++ b/blog/author/kamalmahtani/index.html
@@ -603,7 +603,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/breaches-of-publication-ethics-at-annals/index.html
+++ b/blog/breaches-of-publication-ethics-at-annals/index.html
@@ -1316,7 +1316,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/breaches-of-publication-ethics-at-annals/index.html?replytocom=559.html
+++ b/blog/breaches-of-publication-ethics-at-annals/index.html?replytocom=559.html
@@ -1319,7 +1319,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html
@@ -2819,7 +2819,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=158.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=158.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=159.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=159.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=160.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=160.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=163.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=163.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=164.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=164.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=165.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=165.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=167.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=167.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=168.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=168.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=1717.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=1717.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=182.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=182.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=219.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=219.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=325.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=325.html
@@ -2822,7 +2822,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=399.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=399.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=551.html
+++ b/blog/how-did-nejm-respond-when-we-tried-to-correct-20-misreported-trials/index.html?replytocom=551.html
@@ -2820,7 +2820,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/index.html
+++ b/blog/index.html
@@ -2261,7 +2261,7 @@ Henry Drysdale, Ben Goldacre, and Carl Heneghan on behalf of the COMPare team.'
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/jama-reject-all-correction-letters/index.html
+++ b/blog/jama-reject-all-correction-letters/index.html
@@ -1839,7 +1839,7 @@ First, one paragraph of background, for those unfamiliar with the problem of out
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/jama-reject-all-correction-letters/index.html?replytocom=475.html
+++ b/blog/jama-reject-all-correction-letters/index.html?replytocom=475.html
@@ -1840,7 +1840,7 @@ First, one paragraph of background, for those unfamiliar with the problem of out
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/lessons/erase.html
+++ b/blog/lessons/erase.html
@@ -1878,7 +1878,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/lessons/erase/index.html
+++ b/blog/lessons/erase/index.html
@@ -1880,7 +1880,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/lessons/erase?replytocom=460.html
+++ b/blog/lessons/erase?replytocom=460.html
@@ -1881,7 +1881,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/outcome-switching-what-does-the-icmje-say/index.html
+++ b/blog/outcome-switching-what-does-the-icmje-say/index.html
@@ -957,7 +957,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/outcome-switching-what-does-the-icmje-say/index.html?replytocom=540.html
+++ b/blog/outcome-switching-what-does-the-icmje-say/index.html?replytocom=540.html
@@ -958,7 +958,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/page/2/index.html
+++ b/blog/page/2/index.html
@@ -1373,7 +1373,7 @@ Henry Drysdale, Ben Goldacre, and Carl Heneghan on behalf of the COMPare team.'
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/page/3/index.html
+++ b/blog/page/3/index.html
@@ -1142,7 +1142,7 @@ Henry Drysdale, Ben Goldacre, and Carl Heneghan on behalf of the COMPare team.'
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/post-hoc-pre-specification-and-undeclared-separation-of-results-a-broken-record-in-the-making/index.html
+++ b/blog/post-hoc-pre-specification-and-undeclared-separation-of-results-a-broken-record-in-the-making/index.html
@@ -1247,7 +1247,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/post-hoc-pre-specification-and-undeclared-separation-of-results-a-broken-record-in-the-making/index.html?replytocom=351.html
+++ b/blog/post-hoc-pre-specification-and-undeclared-separation-of-results-a-broken-record-in-the-making/index.html?replytocom=351.html
@@ -1250,7 +1250,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/reeact-in-the-bmj-good-science-in-action/index.html
+++ b/blog/reeact-in-the-bmj-good-science-in-action/index.html
@@ -1102,7 +1102,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/reeact-in-the-bmj-good-science-in-action/index.html?replytocom=511.html
+++ b/blog/reeact-in-the-bmj-good-science-in-action/index.html?replytocom=511.html
@@ -1105,7 +1105,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/tag/annals/index.html
+++ b/blog/tag/annals/index.html
@@ -485,7 +485,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/tag/bmj/index.html
+++ b/blog/tag/bmj/index.html
@@ -437,7 +437,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/tag/jama/index.html
+++ b/blog/tag/jama/index.html
@@ -693,7 +693,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/tag/nejm/index.html
+++ b/blog/tag/nejm/index.html
@@ -501,7 +501,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html
+++ b/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html
@@ -1510,7 +1510,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=797.html
+++ b/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=797.html
@@ -1513,7 +1513,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=801.html
+++ b/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=801.html
@@ -1513,7 +1513,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=802.html
+++ b/blog/the-lancet-and-compare-why-journals-should-address-outcome-switching-themselves/index.html?replytocom=802.html
@@ -1513,7 +1513,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html
+++ b/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html
@@ -1840,7 +1840,7 @@ The COMPare project sets out to address the problem of o"
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html
+++ b/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html
@@ -562,9 +562,9 @@ The COMPare project sets out to address the problem of o"
                       >and we are happy to review coding in the light of
                       commentary from authors. Our email address,
                     </span></span
-                  ><a href="mailto:compare-team@ebmdatalab.net"
+                  ><a href="mailto:ebmdatalab@phc.ox.ac.uk"
                     ><span style="font-weight: 400"
-                      >compare-team@ebmdatalab.net</span
+                      >ebmdatalab@phc.ox.ac.uk</span
                     ></a
                   ><span style="font-weight: 400"
                     >,

--- a/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html?replytocom=177.html
+++ b/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html?replytocom=177.html
@@ -1844,7 +1844,7 @@ The COMPare project sets out to address the problem of o"
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html?replytocom=177.html
+++ b/blog/where-does-annals-of-internal-medicine-stand-on-outcome-switching-a-detailed-response/index.html?replytocom=177.html
@@ -563,9 +563,9 @@ The COMPare project sets out to address the problem of o"
                       >and we are happy to review coding in the light of
                       commentary from authors. Our email address,
                     </span></span
-                  ><a href="mailto:compare-team@ebmdatalab.net"
+                  ><a href="mailto:ebmdatalab@phc.ox.ac.uk"
                     ><span style="font-weight: 400"
-                      >compare-team@ebmdatalab.net</span
+                      >ebmdatalab@phc.ox.ac.uk</span
                     ></a
                   ><span style="font-weight: 400"
                     >,

--- a/faq.html
+++ b/faq.html
@@ -797,7 +797,7 @@ No specific funding has been sought for COMPare. The PI Ben Goldacre receives ac
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/faq.html
+++ b/faq.html
@@ -562,9 +562,9 @@ No specific funding has been sought for COMPare. The PI Ben Goldacre receives ac
                     ><span style="color: #0000ff"
                       ><a
                         style="color: #0000ff"
-                        href="mailto:COMPare-team@ebmdatalab.net"
+                        href="mailto:ebmdatalab@phc.ox.ac.uk"
                         ><span style="font-weight: 400"
-                          >COMPare-team@ebmdatalab.net</span
+                          >ebmdatalab@phc.ox.ac.uk</span
                         ></a
                       ></span
                     ><span style="font-weight: 400">
@@ -602,9 +602,9 @@ No specific funding has been sought for COMPare. The PI Ben Goldacre receives ac
                     ><span style="color: #0000ff"
                       ><a
                         style="color: #0000ff"
-                        href="mailto:COMPare-team@ebmdatalab.net"
+                        href="mailto:ebmdatalab@phc.ox.ac.uk"
                         ><span style="font-weight: 400"
-                          >COMPare-team@ebmdatalab.net</span
+                          >ebmdatalab@phc.ox.ac.uk</span
                         ></a
                       ></span
                     ></span

--- a/fda.html
+++ b/fda.html
@@ -1102,7 +1102,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/fda/index.html
+++ b/fda/index.html
@@ -1102,7 +1102,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/fda?replytocom=1709.html
+++ b/fda?replytocom=1709.html
@@ -1105,7 +1105,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/methods.html
+++ b/methods.html
@@ -450,8 +450,8 @@ Why outcome switchin"
                   >
                   first, as your question may be answered there. We are happy to
                   receive feedback:
-                  <a href="mailto:compare-team@ebmdatalab.net"
-                    >compare-team@ebmdatalab.net</a
+                  <a href="mailto:ebmdatalab@phc.ox.ac.uk"
+                    >ebmdatalab@phc.ox.ac.uk</a
                   >.
                 </p>
                 <div class="social">

--- a/methods.html
+++ b/methods.html
@@ -641,7 +641,7 @@ Why outcome switchin"
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/project.html
+++ b/project.html
@@ -450,8 +450,8 @@ Why outcome switchin"
                   >
                   first, as your question may be answered there. We are happy to
                   receive feedback:
-                  <a href="mailto:compare-team@ebmdatalab.net"
-                    >compare-team@ebmdatalab.net</a
+                  <a href="mailto:ebmdatalab@phc.ox.ac.uk"
+                    >ebmdatalab@phc.ox.ac.uk</a
                   >.
                 </p>
                 <div class="social">

--- a/project.html
+++ b/project.html
@@ -641,7 +641,7 @@ Why outcome switchin"
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/results.html
+++ b/results.html
@@ -524,7 +524,7 @@ Loading trials..."
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/speaking.html
+++ b/speaking.html
@@ -584,7 +584,7 @@
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>

--- a/speaking.html
+++ b/speaking.html
@@ -395,7 +395,7 @@
                 <p>
                   If you&#8217;d like us to speak at your local Skeptics in the
                   Pub,
-                  <a href="mailto:compare-team@ebmdatalab.net">get in touch</a>.
+                  <a href="mailto:ebmdatalab@phc.ox.ac.uk">get in touch</a>.
                 </p>
                 <div class="social">
                   <a

--- a/team.html
+++ b/team.html
@@ -179,7 +179,7 @@
       property="og:description"
       content="We are a team of academics, medical students and programmers, based at the Centre for Evidence-Based Medicine, at the University of Oxford.
 
-We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
+We welcome questions and feedback: ebmdatalab@phc.ox.ac.uk. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
     />
     <meta
       property="og:image"
@@ -191,7 +191,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
       itemprop="description"
       content="We are a team of academics, medical students and programmers, based at the Centre for Evidence-Based Medicine, at the University of Oxford.
 
-We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
+We welcome questions and feedback: ebmdatalab@phc.ox.ac.uk. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
     />
     <meta
       itemprop="image"
@@ -204,7 +204,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
       name="twitter:description"
       content="We are a team of academics, medical students and programmers, based at the Centre for Evidence-Based Medicine, at the University of Oxford.
 
-We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
+We welcome questions and feedback: ebmdatalab@phc.ox.ac.uk. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
     />
     <meta
       name="twitter:image"
@@ -217,7 +217,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
       name="description"
       content="We are a team of academics, medical students and programmers, based at the Centre for Evidence-Based Medicine, at the University of Oxford.
 
-We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
+We welcome questions and feedback: ebmdatalab@phc.ox.ac.uk. However, if you have questions about our methodology, please read our full protocol (PDF) fi"
     />
     <!-- Misc. tags -->
     <!-- END - Facebook Open Graph, Google+ and Twitter Card Tags 2.0.4 -->

--- a/team.html
+++ b/team.html
@@ -322,15 +322,15 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
               <div class="entry-content" itemprop="text">
                 <p>
                   We are a team of academics, medical students and programmers,
-                  based at the
-                  <a href="https://cebm.net"
-                    >Centre for Evidence-Based Medicine</a
+                  based from the
+                  <a href="https://www.bennett.ox.ac.uk/"
+                    >Bennett Institute for Applied Data Science</a
                   >, at the University of Oxford.
                 </p>
                 <p>
                   We welcome questions and feedback:
-                  <a href="mailto:compare-team@ebmdatalab.net"
-                    >compare-team@ebmdatalab.net</a
+                  <a href="mailto:ebmdatalab@phc.ox.ac.uk"
+                    >ebmdatalab@phc.ox.ac.uk</a
                   >. However, if you have questions about our methodology,
                   please read our
                   <a
@@ -384,7 +384,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
                           the Department for Education on how to improve the use
                           of evidence in teaching; and is co-founder of
                           <a
-                            href='https://www.compare-trials.org/"https://www.alltrials.net/"'
+                            href='https://www.alltrials.net/'
                             >AllTrials</a
                           >, a campaign by doctors, academics, funders,
                           pharmacists, professional bodies, patients and the
@@ -394,38 +394,38 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
                           Ben is currently a Senior Clinical Research Fellow at
                           the
                           <a
-                            href='https://www.compare-trials.org/"https://www.cebm.net/"'
+                            href='https://www.cebm.net/'
                             >Centre for Evidence-Based Medicine</a
                           >
                           in the Department of Primary Care in the University of
                           Oxford, and a Research Fellow in Epidemiology at
                           <a
-                            href='https://www.compare-trials.org/"https://www.lshtm.ac.uk"'
+                            href='https://www.lshtm.ac.uk'
                             >LSHTM</a
                           >. He runs the
                           <a
-                            href='https://www.compare-trials.org/"https://ebmdatalab.net"'
-                            >EBM Data Lab</a
+                            href='https://www.bennett.ox.ac.uk/'
+                            >Bennett Institute for Applied Data Science</a
                           >
                           in the University of Oxford and builds interesting
                           live data tools to improve science and healthcare,
                           like
                           <a
-                            href='https://www.compare-trials.org/"https://openprescribing.net"'
+                            href='https://openprescribing.net'
                             >OpenPrescribing</a
                           >
                           and
                           <a
-                            href='https://www.compare-trials.org/"https://opentrials.net/"'
+                            href='https://opentrials.net/'
                             >OpenTrials</a
                           >. His blog is at
                           <a
-                            href='https://www.compare-trials.org/"https://www.badscience.net"'
+                            href='https://www.badscience.net'
                             >badscience.net</a
                           >
                           and he is
                           <a
-                            href='https://www.compare-trials.org/"https://twitter.com/bengoldacre"'
+                            href='https://twitter.com/bengoldacre'
                             >@bengoldacre</a
                           >
                           on Twitter.
@@ -694,7 +694,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
                         >Centre for Evidence-Based Medicine</a
                       >
                       on various projects for the
-                      <a href="https://ebmdatalab.net">EBM Data Lab</a>. You can
+                      <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>. You can
                       see more of her work at
                       <a href="https://anna.ps">anna.ps</a> and she is
                       <a href="https://twitter.com/darkgreener">@darkgreener</a>
@@ -889,7 +889,7 @@ We welcome questions and feedback: compare-team@ebmdatalab.net. However, if you 
 
           <p>
             Copyright &#x000A9;&nbsp;2019 &middot;
-            <a href="https://ebmdatalab.net">EBM Data Lab</a>
+            <a href="https://www.bennett.ox.ac.uk/">Bennett Institute for Applied Data Science</a>
           </p>
         </div>
       </footer>


### PR DESCRIPTION
Update references to our team to use the name "Bennett Institute for Applied Data Science" and https://www.bennett.ox.ac.uk/ web address.